### PR TITLE
fix "Prefer `format()` over `%`  for string interpolation" issue

### DIFF
--- a/mongobean/orm.py
+++ b/mongobean/orm.py
@@ -16,7 +16,7 @@ def ensure_indices():
     for name,document_class in document_classes.items():
         print name
         if hasattr(document_class,'indices'):
-            print "Adding indices to class %s" % document_class.__name__
+            print "Adding indices to class {0!s}".format(document_class.__name__)
             document_class.collection.create_index(document_class.indices)
 
 def register(cls):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over `%`  for string interpolation](http://localhost:5000/app/issue_class/4ACGxFj1)
Issue details: [http://localhost:5000/app/project/gh:adewes:mongobean?groups=code_patterns/%3A4ACGxFj1](http://localhost:5000/app/project/gh:adewes:mongobean?groups=code_patterns/%3A4ACGxFj1)

I do not claim any copyright on the changes.
If you need to adjust the commit messages or the individual changes, feel free to rebase, cherry-pick or do whatever you consider appropriate with my commits.
For questions, feedback or small talk you can contact me at cody@quantifiedcode.com.

Cheers,
[Cody](https://www.quantifiedcode.com/cody)