### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mongobean/orm.py
+++ b/mongobean/orm.py
@@ -16,7 +16,7 @@ def ensure_indices():
     for name,document_class in document_classes.items():
         print name
         if hasattr(document_class,'indices'):
-            print "Adding indices to class %s" % document_class.__name__
+            print "Adding indices to class {0!s}".format(document_class.__name__)
             document_class.collection.create_index(document_class.indices)
 
 def register(cls):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:adewes:mongobean?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:adewes:mongobean?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)